### PR TITLE
feat: add locale switcher and internationalization support

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,35 @@
+{
+  "AppLayout": {
+    "home": "Home",
+    "logout": "Logout",
+    "profile": "Profile"
+  },
+  "Hero": {
+    "badge": "Create, share, live.",
+    "title": "For those who love living in the moment.",
+    "button": "See all events"
+  },
+
+  "HomePage": {
+    "title": "Home"
+  },
+  "LocaleSwitcher": {
+    "fr": "French",
+    "en": "English",
+    "label": "Language"
+  },
+  "LoginPage": {
+    "credentials": "Credentials: jane@doe.com / next-intl",
+    "description": "Please enter your details.",
+    "email": "Email",
+    "invalidCredentials": "Please check your credentials.",
+    "invalidEmail": "Please enter a valid email address.",
+    "invalidPassword": "Please enter a password.",
+    "login": "Sign in",
+    "password": "Password",
+    "title": "Welcome back"
+  },
+  "ProfilePage": {
+    "title": "Profile"
+  }
+}

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,0 +1,34 @@
+{
+  "AppLayout": {
+    "home": "Accueil",
+    "logout": "Déconnexion",
+    "profile": "Profil"
+  },
+  "Hero": {
+    "badge": "Créez, partagez, vivez.",
+    "title": "Pour ceux qui aiment vivre l'instant.",
+    "button": "Voir tous les événements"
+  },
+  "HomePage": {
+    "title": "Accueil"
+  },
+  "LocaleSwitcher": {
+    "fr": "Français",
+    "en": "Anglais",
+    "label": "Langue"
+  },
+  "LoginPage": {
+    "credentials": "Identifiants: jane@doe.com / next-intl",
+    "description": "Veuillez saisir vos informations.",
+    "email": "Email",
+    "invalidCredentials": "Veuillez vérifier vos identifiants.",
+    "invalidEmail": "Veuillez saisir une adresse email valide.",
+    "invalidPassword": "Veuillez saisir un mot de passe.",
+    "login": "Se connecter",
+    "password": "Mot de passe",
+    "title": "Bon retour"
+  },
+  "ProfilePage": {
+    "title": "Profil"
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,11 @@
 import type { NextConfig } from "next";
+import withNextIntl from "next-intl/plugin";
 
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: [
-      { hostname: "yala.events" },
-      { hostname: "storage.yala.events" },
-    ],
+    remotePatterns: [{ hostname: "yala.events" }, { hostname: "storage.yala.events" }],
 
     //TODO: Check if this is needed and if it is the good config
-
     minimumCacheTTL: 300,
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
@@ -16,4 +13,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withNextIntl()(nextConfig);

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lucide-react": "^0.462.0",
     "next": "15.1.3",
     "next-auth": "^4.24.8",
+    "next-intl": "^3.26.3",
     "next-themes": "^0.4.3",
     "react": "^19.0.0",
     "react-day-picker": "8.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       next-auth:
         specifier: ^4.24.8
         version: 4.24.11(next@15.1.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next-intl:
+        specifier: ^3.26.3
+        version: 3.26.3(next@15.1.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       next-themes:
         specifier: ^0.4.3
         version: 0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -316,6 +319,21 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@formatjs/ecma402-abstract@2.3.2':
+    resolution: {integrity: sha512-6sE5nyvDloULiyOMbOTJEEgWL32w+VHkZQs8S02Lnn8Y/O5aQhjOEXwWzvR7SsBE/exxlSpY2EsWZgqHbtLatg==}
+
+  '@formatjs/fast-memoize@2.2.6':
+    resolution: {integrity: sha512-luIXeE2LJbQnnzotY1f2U2m7xuQNj2DA8Vq4ce1BY9ebRZaoPB1+8eZ6nXpLzsxuW5spQxr7LdCg+CApZwkqkw==}
+
+  '@formatjs/icu-messageformat-parser@2.10.0':
+    resolution: {integrity: sha512-PDeky6nDAyHYEtmSi2X1PG9YpqE+2BRTJT7JvPix8K8JX1wBWQNao6KcPtmZpttQHUHmzMcd/rne7lFesSzUKQ==}
+
+  '@formatjs/icu-skeleton-parser@1.8.12':
+    resolution: {integrity: sha512-QRAY2jC1BomFQHYDMcZtClqHR55EEnB96V7Xbk/UiBodsuFc5kujybzt87+qj1KqmJozFhk6n4KiT1HKwAkcfg==}
+
+  '@formatjs/intl-localematcher@0.5.10':
+    resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
 
   '@googlemaps/js-api-loader@1.16.8':
     resolution: {integrity: sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ==}
@@ -1841,6 +1859,9 @@ packages:
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
+  decimal.js@10.4.3:
+    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2283,6 +2304,9 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  intl-messageformat@10.7.12:
+    resolution: {integrity: sha512-4HBsPDJ61jZwNikauvm0mcLvs1AfCBbihiqOX2AGs1MX7SA1H0SNKJRSWxpZpToGoNzvoYLsJJ2pURkbEDg+Dw==}
+
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
@@ -2553,6 +2577,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   next-auth@4.24.11:
     resolution: {integrity: sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==}
     peerDependencies:
@@ -2566,6 +2594,12 @@ packages:
         optional: true
       nodemailer:
         optional: true
+
+  next-intl@3.26.3:
+    resolution: {integrity: sha512-6Y97ODrDsEE1J8cXKMHwg1laLdtkN66QMIqG8BzH4zennJRUNTtM8UMtBDyhfmF6uiZ+xsbWLXmHUgmUymUsfQ==}
+    peerDependencies:
+      next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
   next-themes@0.4.4:
     resolution: {integrity: sha512-LDQ2qIOJF0VnuVrrMSMLrWGjRMkq+0mpgl6e0juCLqdJ+oo8Q84JRWT6Wh11VDQKkMMe+dVzDKLWs5n87T+PkQ==}
@@ -3197,6 +3231,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-intl@3.26.3:
+    resolution: {integrity: sha512-yY0a2YseO17cKwHA9M6fcpiEJ2Uo81DEU0NOUxNTp6lJVNOuI6nULANPVVht6IFdrYFtlsMmMoc97+Eq9/Tnng==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
     engines: {node: '>=10'}
@@ -3363,6 +3402,32 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@formatjs/ecma402-abstract@2.3.2':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.6
+      '@formatjs/intl-localematcher': 0.5.10
+      decimal.js: 10.4.3
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.6':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.10.0':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.2
+      '@formatjs/icu-skeleton-parser': 1.8.12
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.12':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.2
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.5.10':
+    dependencies:
+      tslib: 2.8.1
 
   '@googlemaps/js-api-loader@1.16.8': {}
 
@@ -4934,6 +4999,8 @@ snapshots:
 
   decimal.js-light@2.5.1: {}
 
+  decimal.js@10.4.3: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -5510,6 +5577,13 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  intl-messageformat@10.7.12:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.2
+      '@formatjs/fast-memoize': 2.2.6
+      '@formatjs/icu-messageformat-parser': 2.10.0
+      tslib: 2.8.1
+
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
@@ -5771,6 +5845,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   next-auth@4.24.11(next@15.1.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.26.0
@@ -5785,6 +5861,14 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       uuid: 8.3.2
+
+  next-intl@3.26.3(next@15.1.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@formatjs/intl-localematcher': 0.5.10
+      negotiator: 1.0.0
+      next: 15.1.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      use-intl: 3.26.3(react@19.0.0)
 
   next-themes@0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -6522,6 +6606,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.4
+
+  use-intl@3.26.3(react@19.0.0):
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.6
+      intl-messageformat: 10.7.12
+      react: 19.0.0
 
   use-sidecar@1.1.3(@types/react@19.0.4)(react@19.0.0):
     dependencies:

--- a/src/components/sections/hero.tsx
+++ b/src/components/sections/hero.tsx
@@ -4,10 +4,12 @@ import image1 from "@public/images/sliders/afrique-event.jpg";
 import image2 from "@public/images/sliders/evenement-fete.jpeg";
 import image3 from "@public/images/sliders/evenement-mode.jpeg";
 import { MoveRight } from "lucide-react";
+import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Section from "../ui/custom/section";
 
 export const Hero = () => {
+  const t = useTranslations("Hero");
   const images = [image1, image2, image3];
   const shuffledImages = [...images].sort(() => Math.random() - 0.5);
 
@@ -16,14 +18,14 @@ export const Hero = () => {
       <div className="grid grid-cols-1 gap-4 items-center md:grid-cols-2 h-full">
         <div className="flex gap-4 flex-col">
           <div>
-            <Badge variant="outline">Créez, partagez, vivez.</Badge>
+            <Badge variant="outline">{t("badge")}</Badge>
           </div>
           <div className="flex gap-4 flex-col">
-            <h1 className="tracking-tighter text-left font-semibold">Pour ceux qui aiment vivre l&apos;instant.</h1>
+            <h1 className="tracking-tighter text-left font-semibold">{t("title")}</h1>
           </div>
           <div className="flex flex-row gap-4">
             <Button size="lg" className="gap-4">
-              Voir tout les événements <MoveRight className="w-4 h-4" />
+              {t("button")} <MoveRight className="w-4 h-4" />
             </Button>
           </div>
         </div>

--- a/src/components/shared/main-header.tsx
+++ b/src/components/shared/main-header.tsx
@@ -16,12 +16,14 @@ import { AuthStatus } from "./auth-status";
 import { Logo } from "./logo";
 import { MobileMenu } from "./mobile-menu";
 import { ModeToggleFront } from "./mode-toggle-front";
+import LocaleSwitcher from "./translate/LocaleSwitcher";
 
 export const MainHeader = () => {
   return (
     <header className="w-full top-0 left-0 bg-background">
       <div className="container relative mx-auto min-h-20 flex gap-4 flex-row  items-center  justify-between">
         <div className="hidden lg:flex items-center max-w-md w-full">
+          <LocaleSwitcher />
           <div className="relative w-full">
             <Input
               type="search"
@@ -54,17 +56,13 @@ export const MainHeader = () => {
                       </>
                     ) : (
                       <>
-                        <NavigationMenuTrigger className="font-medium text-xs">
-                          {item.title}
-                        </NavigationMenuTrigger>
+                        <NavigationMenuTrigger className="font-medium text-xs">{item.title}</NavigationMenuTrigger>
                         <NavigationMenuContent className="!w-[450px] p-4">
                           <div className="flex flex-col lg:grid grid-cols-2 gap-4">
                             <div className="flex flex-col h-full justify-between">
                               <div className="flex flex-col">
                                 <p className="text-base">{item.title}</p>
-                                <p className="text-muted-foreground text-sm">
-                                  {item.description}
-                                </p>
+                                <p className="text-muted-foreground text-sm">{item.description}</p>
                               </div>
                               <Button size="sm" className="mt-10">
                                 Book a call today

--- a/src/components/shared/translate/LocaleSwitcher.tsx
+++ b/src/components/shared/translate/LocaleSwitcher.tsx
@@ -1,0 +1,24 @@
+import { useLocale, useTranslations } from "next-intl";
+import LocaleSwitcherSelect from "./LocaleSwitcherSelect";
+
+export default function LocaleSwitcher() {
+  const t = useTranslations("LocaleSwitcher");
+  const locale = useLocale();
+
+  return (
+    <LocaleSwitcherSelect
+      defaultValue={locale}
+      items={[
+        {
+          value: "en",
+          label: t("en"),
+        },
+        {
+          value: "fr",
+          label: t("fr"),
+        },
+      ]}
+      label={t("label")}
+    />
+  );
+}

--- a/src/components/shared/translate/LocaleSwitcherSelect.tsx
+++ b/src/components/shared/translate/LocaleSwitcherSelect.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Locale } from "@/i18n/config";
+import { setUserLocale } from "@/server/services/local.service";
+import * as Select from "@radix-ui/react-select";
+import clsx from "clsx";
+import { CheckIcon, ChevronDown, Languages } from "lucide-react";
+import { useTransition } from "react";
+
+type Props = {
+  defaultValue: string;
+  items: Array<{ value: string; label: string }>;
+  label: string;
+};
+
+export default function LocaleSwitcherSelect({ defaultValue, items, label }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  function onChange(value: string) {
+    const locale = value as Locale;
+    startTransition(() => {
+      setUserLocale(locale);
+    });
+  }
+
+  return (
+    <div className="relative">
+      <Select.Root defaultValue={defaultValue} onValueChange={onChange}>
+        <Select.Trigger
+          aria-label={label}
+          className={clsx(
+            "inline-flex items-center justify-between rounded-md px-3 py-2",
+            "bg-background text-sm font-medium",
+            "text-foreground shadow-sm",
+            "hover:bg-accent",
+            "focus:outline-none focus:ring-2 focus:ring-ring",
+            "transition-all duration-200 ease-in-out",
+            isPending && "pointer-events-none opacity-60"
+          )}
+        >
+          <div className="flex items-center gap-2">
+            <Languages className="h-4 w-4 text-muted-foreground" />
+            <span className="hidden sm:inline">{items.find((item) => item.value === defaultValue)?.label}</span>
+          </div>
+          <ChevronDown className="ml-2 h-4 w-4 text-muted-foreground" />
+        </Select.Trigger>
+
+        <Select.Portal>
+          <Select.Content
+            className="z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-background shadow-lg animate-in fade-in-80"
+            position="popper"
+            align="end"
+            sideOffset={5}
+          >
+            <Select.Viewport className="p-1">
+              {items.map((item) => (
+                <Select.Item
+                  key={item.value}
+                  value={item.value}
+                  className={clsx(
+                    "relative flex items-center gap-2 rounded-sm px-4 py-2 text-sm",
+                    "text-foreground",
+                    "cursor-pointer select-none",
+                    "data-[highlighted]:bg-accent",
+                    "outline-none focus:bg-accent"
+                  )}
+                >
+                  <Select.ItemText>{item.label}</Select.ItemText>
+                  {item.value === defaultValue && <CheckIcon className="ml-auto h-4 w-4 text-primary" />}
+                </Select.Item>
+              ))}
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
+      </Select.Root>
+    </div>
+  );
+}

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,0 +1,4 @@
+export type Locale = (typeof locales)[number];
+
+export const locales = ["en", "fr"] as const;
+export const defaultLocale: Locale = "en";

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,11 @@
+import { getUserLocale } from "@/server/services/local.service";
+import { getRequestConfig } from "next-intl/server";
+
+export default getRequestConfig(async () => {
+  const locale = await getUserLocale();
+
+  return {
+    locale,
+    messages: (await import(`../../messages/${locale}.json`)).default,
+  };
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,7 @@ export default withAuth({
 
 export const config = {
   matcher: [
-    "/tableau-de-bord",
-    "/tableau-de-bord/:path*", // Protège toutes les sous-routes du tableau de bord
+    "/board",
+    "/board/:path*", // Protège toutes les sous-routes du tableau de bord
   ],
 };

--- a/src/server/services/local.service.ts
+++ b/src/server/services/local.service.ts
@@ -1,0 +1,16 @@
+"use server";
+
+import { Locale, defaultLocale } from "@/i18n/config";
+import { cookies } from "next/headers";
+
+const COOKIE_NAME = "NEXT_LOCALE";
+
+export async function getUserLocale() {
+  const cookieStore = await cookies();
+  return cookieStore.get(COOKIE_NAME)?.value || defaultLocale;
+}
+
+export async function setUserLocale(locale: Locale) {
+  const cookieStore = await cookies();
+  cookieStore.set(COOKIE_NAME, locale);
+}


### PR DESCRIPTION
- Add `LocaleSwitcher` and `LocaleSwitcherSelect` components to allow users to switch between English and French
- Implement `getUserLocale` and `setUserLocale` functions to manage user locale in cookies
- Add `next-intl` package and configure it in `next.config.ts` and `src/i18n/request.ts`
- Add French and English translations in `messages/fr.json` and `messages/en.json`