### PR TITLE
refactor: remove unnecessary auth headers from event services

### DIFF
--- a/src/server/services/event-categories.service.ts
+++ b/src/server/services/event-categories.service.ts
@@ -1,6 +1,5 @@
 import { EventCategory } from "@/types/api/event-category.type";
 import { ApiErrorHandler } from "@/utils/api-error";
-import { getAuthHeaders } from "@/utils/auth-utils";
 import api from "@/utils/axios-instance";
 
 export interface EventCategoriesResponse {
@@ -13,14 +12,12 @@ export interface EventCategoriesResponse {
 
 export const fetchEventCategories = async (): Promise<EventCategoriesResponse> => {
   try {
-    const headers = await getAuthHeaders();
-    const { data } = await api.get("/events-categories", { headers });
+    const { data } = await api.get("/events-categories");
     return data;
   } catch (error) {
     return ApiErrorHandler.handle<EventCategoriesResponse>(
       error,
       "Une erreur est survenue lors de la récupération des catégories d'événements"
-      
     );
   }
 };

--- a/src/server/services/event-formats.service.ts
+++ b/src/server/services/event-formats.service.ts
@@ -1,6 +1,5 @@
 import { EventFormat } from "@/types/api/event-format.type";
 import { ApiErrorHandler } from "@/utils/api-error";
-import { getAuthHeaders } from "@/utils/auth-utils";
 import api from "@/utils/axios-instance";
 
 export interface EventFormatsResponse {
@@ -13,8 +12,7 @@ export interface EventFormatsResponse {
 
 export const fetchEventFormats = async (): Promise<EventFormatsResponse> => {
   try {
-    const headers = await getAuthHeaders();
-    const { data } = await api.get("/events-formats", { headers });
+    const { data } = await api.get("/events-formats");
     return data;
   } catch (error) {
     return ApiErrorHandler.handle<EventFormatsResponse>(

--- a/src/server/services/event-types.service.ts
+++ b/src/server/services/event-types.service.ts
@@ -1,6 +1,5 @@
 import { EventType } from "@/types/api/event-type.type";
 import { ApiErrorHandler } from "@/utils/api-error";
-import { getAuthHeaders } from "@/utils/auth-utils";
 import api from "@/utils/axios-instance";
 
 export interface EventTypesResponse {
@@ -13,8 +12,7 @@ export interface EventTypesResponse {
 
 export const fetchEventTypes = async (): Promise<EventTypesResponse> => {
   try {
-    const headers = await getAuthHeaders();
-    const { data } = await api.get("/events-types", { headers });
+    const { data } = await api.get("/events-types");
     return data;
   } catch (error) {
     return ApiErrorHandler.handle<EventTypesResponse>(error, "Une erreur est survenue lors de la récupération des types d'événements");


### PR DESCRIPTION
- Removed `getAuthHeaders` function calls from `event-categories.service.ts`, `event-types.service.ts`, and `event-formats.service.ts`
- Simplified API calls by directly using the `api.get` method without passing headers